### PR TITLE
add default headers p.e. for testing with mobile user agents

### DIFF
--- a/lib/jellyproxy.js
+++ b/lib/jellyproxy.js
@@ -129,9 +129,16 @@ exports.jellyproxy = function(_this) {
 
        // Stop from requesting gzip
        req.headers['accept-encoding'] = "text/html";
-       
-       var proxyRequest = c.request(req.method, pathname, req.headers);
-       
+
+       // allow additional default headers
+       var headers={},h;
+
+       for(h in req.headers)headers[h]=req.headers[h];
+
+       if(_this.default_headers)for(h in _this.default_headers)headers[h]=_this.default_headers[h];
+
+       var proxyRequest = c.request(req.method, pathname, headers);
+
        var clientError = function (e) { 
          if (!res._header) {
            res.writeHead(502, {})


### PR DESCRIPTION
example use case:

var browser = jellyfish.createJellyfish("firefox", "http://m.test2.o2online.de/vertrag/verbrauch", that.callback);

browser.default_headers =
                {    'X-WAPCLI':'491792412158',
                    'User-Agent':'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3',
                };
