### PR TITLE
This is the correct way of launching google chrome. If the `--homepage` ...

### DIFF
--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -130,6 +130,7 @@ chrome = function(_this) {
     
     _this.bid = uuid();
     var flags = [
+      url,
       "--user-data-dir="+process.env.TMPDIR+_this.bid,
       "--disable-prompt-on-repost",
       "--disable-metrics",
@@ -138,8 +139,7 @@ chrome = function(_this) {
       "--disable-web-security",
       "--temp-profile",
       "--no-first-run",
-      "--disable-popup-blocking", 
-      "--homepage="+url
+      "--disable-popup-blocking"
     ]
     
     if (port) {


### PR DESCRIPTION
try both (on a mac): 

``` bash
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome http://localhost:8888 --no-default-browser-check --temp-profile --disable-web-security --disable-prompt-on-repost --disable-metrics --disable-metrics-reporting --no-first-run --disable-popup-blocking --user-data-dir="/tmp/some"
```

``` bash
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --homepage="http://localhost:8888" --no-default-browser-check --temp-profile --disable-web-security --disable-prompt-on-repost --disable-metrics --disable-metrics-reporting --no-first-run --disable-popup-blocking --user-data-dir="/tmp/some"
```

And you'll understand.
Got this from here: http://stackoverflow.com/questions/10488920/bash-script-to-open-chrome-then-turn-computer-off-when-chrome-is-closed
